### PR TITLE
Use correct test for paths vs lockers; fix -f

### DIFF
--- a/attach
+++ b/attach
@@ -257,7 +257,7 @@ if (len(argv) > 0) and (argv[0] == "-Padd"):
     lockers = []
     paths = []
     for x in args + atargs:
-        if '/' in x:
+        if x.startswith('.') or x.startswith('/'):
             paths.append(x)
         else:
             lockers.append(x)
@@ -295,7 +295,10 @@ if (len(argv) > 0) and (argv[0] == "-Padd"):
             if mountpoint is not None:
                 env.addLocker(mountpoint, options)
         for p in paths:
-            env['PATH'].append(p)
+            if options.front:
+                env['PATH'].insert(0, p)
+            else:
+                env['PATH'].append(p)
     print env.toShell(options.bourne)
 else:
     (options, args) = attachParser.parse_args(argv)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='locker-support',
-      version='10.4.5',
+      version='10.4.6',
       author='Debathena Project',
       author_email='debathena@mit.edu',
       py_modules=['locker', 'athdir'],


### PR DESCRIPTION
- Per the man page, something is a path (not a locker) if it
  starts with '.' or '/'
- Adding a path now honors "-f" rather than always appending
